### PR TITLE
Harden S3 bucket: encryption, no public access, SSL

### DIFF
--- a/template.yaml
+++ b/template.yaml
@@ -167,6 +167,31 @@ Resources:
         Description: "Bucket for Amazon CloudFront access logs"
         Properties:
             BucketName: !Sub "${ResourcePrefix}-${AWS::AccountId}-cf-access-logs"
+            BucketEncryption:
+              ServerSideEncryptionConfiguration:
+              - ServerSideEncryptionByDefault:
+                  SSEAlgorithm: AES256
+            PublicAccessBlockConfiguration:
+              BlockPublicAcls: Yes
+              BlockPublicPolicy: Yes
+              IgnorePublicAcls: Yes
+              RestrictPublicBuckets: Yes
+    CloudFrontAccessLogsBucketPolicy:
+      Type: "AWS::S3::BucketPolicy"
+      Properties:
+        Bucket: !Ref CloudFrontAccessLogsBucket
+        PolicyDocument:
+          Version: "2012-10-17"
+          Statement:
+          - Effect: Deny
+            Principal: "*"
+            Action: s3:*
+            Resource:
+            - !Sub "${CloudFrontAccessLogsBucket.Arn}"
+            - !Sub "${CloudFrontAccessLogsBucket.Arn}/*"
+            Condition:
+              Bool:
+                "aws:SecureTransport": "false"
 
 # Glue Resources
 # - Database


### PR DESCRIPTION
Fixes #14

*Description of changes:*

For CloudFrontAccessLogsBucket, it enables encryption, blocks public access, and sets bucket policy requiring secure transport .