### PR TITLE
Fix typo

### DIFF
--- a/functions/util.js
+++ b/functions/util.js
@@ -1,7 +1,7 @@
 // Copyright 2018 Amazon.com, Inc. or its affiliates. All Rights Reserved.
 // SPDX-License-Identifier: MIT-0
 const aws = require('aws-sdk');
-const athena = new aws.Athena({ apiVersion: '2017-05-181' });
+const athena = new aws.Athena({ apiVersion: '2017-05-18' });
 
 // s3 URL of the query results (without trailing slash)
 const athenaQueryResultsLocation = process.env.ATHENA_QUERY_RESULTS_LOCATION;


### PR DESCRIPTION
*Issue #, if available:* N/A

*Description of changes:* It looks like `apiVersion` should be a date, and the SDK documentation seems to agree [[1]](https://docs.aws.amazon.com/AWSJavaScriptSDK/latest/AWS/Athena.html)


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.