### PR TITLE
Expire unused Athena Query Results in S3

### DIFF
--- a/template.yaml
+++ b/template.yaml
@@ -167,6 +167,12 @@ Resources:
         Description: "Bucket for Amazon CloudFront access logs"
         Properties:
             BucketName: !Sub "${ResourcePrefix}-${AWS::AccountId}-cf-access-logs"
+            LifecycleConfiguration:
+              Rules:
+                - Id: ExpireAthenaQueryResults
+                  Prefix: athena-query-results/
+                  Status: Enabled
+                  ExpirationInDays: 1
             BucketEncryption:
               ServerSideEncryptionConfiguration:
               - ServerSideEncryptionByDefault:


### PR DESCRIPTION
**Issue:** #19

The folder `athena-query-results` is storing query results generated when we transform CSV files into Parquet files. We don't have a reason to keep these results more than one day. It's derived data anyways.

**Description of changes:**

- Expire temporary Athena Query Results generated from parquet transformation after 1 day.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.