### PR TITLE
fix: resolve js-yaml vulnerability via npm override

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -20,6 +20,7 @@
         "@types/node": "^24.10.13",
         "dotenv": "^17.3.1",
         "jest": "^30.2.0",
+        "js-yaml": ">=4.1.1",
         "ts-jest": "^29.1.0",
         "typescript": "^5.0.0"
       }
@@ -3322,14 +3323,11 @@
       }
     },
     "node_modules/argparse": {
-      "version": "1.0.10",
-      "resolved": "https://registry.npmjs.org/argparse/-/argparse-1.0.10.tgz",
-      "integrity": "sha512-o5Roy6tNG4SL/FOkCAN6RzjiakZS25RLYFrcMttJqbdd8BWrnA+fGz57iN5Pb06pvBGvl5gQ0B48dJlslXvoTg==",
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/argparse/-/argparse-2.0.1.tgz",
+      "integrity": "sha512-8+9WqebbFzpX9OR+Wa6O29asIogeRMzcGtAINdpMHHyAg10f05aSFVBbcEqGf/PXw1EjAZ+q2/bEBg3DvurK3Q==",
       "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "sprintf-js": "~1.0.2"
-      }
+      "license": "Python-2.0"
     },
     "node_modules/babel-jest": {
       "version": "30.4.1",
@@ -3894,20 +3892,6 @@
       "license": "MIT",
       "engines": {
         "node": ">=8"
-      }
-    },
-    "node_modules/esprima": {
-      "version": "4.0.1",
-      "resolved": "https://registry.npmjs.org/esprima/-/esprima-4.0.1.tgz",
-      "integrity": "sha512-eGuFFw7Upda+g4p+QHvnW0RyTX/SVeJBDM/gCtMARO0cLuT2HcEKnTPvhjV6aGeqrCB/sbNop0Kszm0jsaWU4A==",
-      "dev": true,
-      "license": "BSD-2-Clause",
-      "bin": {
-        "esparse": "bin/esparse.js",
-        "esvalidate": "bin/esvalidate.js"
-      },
-      "engines": {
-        "node": ">=4"
       }
     },
     "node_modules/execa": {
@@ -4994,17 +4978,26 @@
       "license": "MIT"
     },
     "node_modules/js-yaml": {
-      "version": "3.14.2",
-      "resolved": "https://registry.npmjs.org/js-yaml/-/js-yaml-3.14.2.tgz",
-      "integrity": "sha512-PMSmkqxr106Xa156c2M265Z+FTrPl+oxd/rgOQy2tijQeK5TxQ43psO1ZCwhVOSdnn+RzkzlRz/eY4BgJBYVpg==",
+      "version": "5.2.3",
+      "resolved": "https://registry.npmjs.org/js-yaml/-/js-yaml-5.2.3.tgz",
+      "integrity": "sha512-n+mUVyUX5bVv7G/G2zyIHOhdxfuU1dY2NOFzTQUWiMUbFss8b57NFlgCCaggU78wSw5KVS9cllzeLyzyR+n5nw==",
       "dev": true,
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/puzrin"
+        },
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/nodeca"
+        }
+      ],
       "license": "MIT",
       "dependencies": {
-        "argparse": "^1.0.7",
-        "esprima": "^4.0.0"
+        "argparse": "^2.0.1"
       },
       "bin": {
-        "js-yaml": "bin/js-yaml.js"
+        "js-yaml": "bin/js-yaml.mjs"
       }
     },
     "node_modules/jsesc": {
@@ -5650,13 +5643,6 @@
         "buffer-from": "^1.0.0",
         "source-map": "^0.6.0"
       }
-    },
-    "node_modules/sprintf-js": {
-      "version": "1.0.3",
-      "resolved": "https://registry.npmjs.org/sprintf-js/-/sprintf-js-1.0.3.tgz",
-      "integrity": "sha512-D9cPgkvLlV3t3IzL0D0YLvGA9Ahk4PcvVwUbN0dSGr1aP0Nrt4AEnTUbuGvquEC0mA64Gqt1fzirlRs5ibXx8g==",
-      "dev": true,
-      "license": "BSD-3-Clause"
     },
     "node_modules/stack-utils": {
       "version": "2.0.6",

--- a/package.json
+++ b/package.json
@@ -23,7 +23,8 @@
     "dotenv": "^17.3.1",
     "jest": "^30.2.0",
     "ts-jest": "^29.1.0",
-    "typescript": "^5.0.0"
+    "typescript": "^5.0.0",
+    "js-yaml": ">=4.1.1"
   },
   "jest": {
     "preset": "ts-jest",
@@ -45,5 +46,11 @@
     "name": "Steffen Grunwald"
   },
   "license": "MIT-0",
-  "homepage": "https://github.com/aws-samples/amazon-cloudfront-access-logs-queries"
+  "homepage": "https://github.com/aws-samples/amazon-cloudfront-access-logs-queries",
+  "overrides": {
+    "js-yaml": "$js-yaml"
+  },
+  "overridesJustification": {
+    "js-yaml": "CVE-2026-53550, CVE-2026-59869 (quadratic DoS in merge-key handling). Transitive via ts-jest -> @jest/transform -> babel-plugin-istanbul -> @istanbuljs/load-nyc-config which pins js-yaml ^3.13.1. The fix requires 4.2.0+ and load-nyc-config has no newer release. Remove this override once load-nyc-config releases a version that drops or upgrades js-yaml."
+  }
 }


### PR DESCRIPTION
js-yaml@3.14.2 is vulnerable to CVE-2026-53550 and CVE-2026-59869 (quadratic DoS in merge key handling). The fix requires 4.2.0+.

Since @istanbuljs/load-nyc-config pins ^3.13.1 and has no newer release, a direct dependency bump cannot resolve the transitive.

Applied npm override: added js-yaml >=4.1.1 as devDependency with $js-yaml reference in overrides to force 5.2.3 across the tree. Added overridesJustification with rationale and removal condition.

SAM template validation passes with no changes.

*Issue #, if available:*

*Description of changes:*


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.